### PR TITLE
Update queries for multi-graph named-graph structure

### DIFF
--- a/1.(Meta)Data/CountPWsPerSpecies.rq
+++ b/1.(Meta)Data/CountPWsPerSpecies.rq
@@ -1,10 +1,23 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# Count pathways per species, using DataNode-level species annotations.
+# Joins: taxonomy-extra (species on DataNodes) + pathways (DataNode → pathway).
+# Species names resolved from the local NCBITaxon ontology.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
 
 SELECT ?species (COUNT(DISTINCT ?pw) AS ?nPathways)
 WHERE {
-  ?pw wp:organismName ?species .
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?node wp:organism ?taxonID .
+    FILTER(?taxonID != ncbi:33090)
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?node dcterms:isPartOf ?pw .
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxonID rdfs:label ?species .
+  }
 }
 GROUP BY ?species
 ORDER BY DESC(?nPathways)

--- a/1.(Meta)Data/GraphIsLoaded.rq
+++ b/1.(Meta)Data/GraphIsLoaded.rq
@@ -8,10 +8,23 @@
 #   graph/ncbitaxon             — NCBITaxon ontology (OBO Foundry, CC0)
 #   void                        — VoID metadata for all datasets
 
+# Uses VALUES to enumerate only the known PlantMetWiki graphs — fast because
+# Virtuoso can use per-graph statistics instead of scanning every triple.
+# (A FILTER on ?graph after GRAPH ?g { ?s ?p ?o } forces a full scan of all
+# graphs including the 21.7M-triple NCBITaxon graph before filtering.)
+
 SELECT ?graph (COUNT(*) AS ?nTriples)
 WHERE {
+  VALUES ?graph {
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways>
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra>
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra>
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon>
+    <http://rdf-plantmetwiki.bioinformatics.nl/void>
+  }
   GRAPH ?graph { ?s ?p ?o . }
-  FILTER(STRSTARTS(STR(?graph), "http://rdf-plantmetwiki.bioinformatics.nl/"))
 }
 GROUP BY ?graph
 ORDER BY DESC(?nTriples)

--- a/1.(Meta)Data/GraphIsLoaded.rq
+++ b/1.(Meta)Data/GraphIsLoaded.rq
@@ -1,3 +1,17 @@
-# Count all triples in the PlantMetWiki named graph
-SELECT (COUNT(*) AS ?nTriples)
-WHERE { ?s ?p ?o . }
+# Count triples per named graph in the PlantMetWiki triplestore.
+# Named graphs:
+#   graph/pathways              — core WikiPathways RDF (pathways + reactions)
+#   graph/gpml-taxonomy-extra   — per-entity species annotations (wp:organism)
+#   graph/gpml-properties-extra — PlantCyc key-value properties
+#   graph/bgc-mibig             — MIBiG curated biosynthetic gene clusters
+#   graph/bgc-plantismash       — plantiSMASH predicted biosynthetic gene clusters
+#   graph/ncbitaxon             — NCBITaxon ontology (OBO Foundry, CC0)
+#   void                        — VoID metadata for all datasets
+
+SELECT ?graph (COUNT(*) AS ?nTriples)
+WHERE {
+  GRAPH ?graph { ?s ?p ?o . }
+  FILTER(STRSTARTS(STR(?graph), "http://rdf-plantmetwiki.bioinformatics.nl/"))
+}
+GROUP BY ?graph
+ORDER BY DESC(?nTriples)

--- a/1.(Meta)Data/ListAllSpecies.rq
+++ b/1.(Meta)Data/ListAllSpecies.rq
@@ -1,7 +1,19 @@
-PREFIX wp: <http://vocabularies.wikipathways.org/wp#>
+# List all species that have at least one annotated DataNode in PlantMetWiki.
+# Species names are resolved via the local NCBITaxon ontology graph.
+# Note: species are annotated at the DataNode level (graph/gpml-taxonomy-extra),
+# not at the pathway level. The pathway level only carries Viridiplantae.
+PREFIX wp:   <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ncbi: <http://purl.obolibrary.org/obo/NCBITaxon_>
 
-SELECT DISTINCT ?species
+SELECT DISTINCT ?taxonID ?species
 WHERE {
-  ?pw wp:organismName ?species .
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?node wp:organism ?taxonID .
+    FILTER(?taxonID != ncbi:33090)  # exclude pathway-level Viridiplantae
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxonID rdfs:label ?species .
+  }
 }
 ORDER BY ?species

--- a/1.(Meta)Data/ListNamedGraphs.rq
+++ b/1.(Meta)Data/ListNamedGraphs.rq
@@ -1,0 +1,9 @@
+# List all named graphs in PlantMetWiki with their triple counts.
+# Useful to verify which datasets are loaded in Virtuoso.
+
+SELECT ?graph (COUNT(*) AS ?nTriples)
+WHERE {
+  GRAPH ?graph { ?s ?p ?o . }
+}
+GROUP BY ?graph
+ORDER BY DESC(?nTriples)

--- a/1.(Meta)Data/Taxa_Missing_from_NCBITaxon.rq
+++ b/1.(Meta)Data/Taxa_Missing_from_NCBITaxon.rq
@@ -1,0 +1,43 @@
+# Find taxa in PlantMetWiki that cannot be resolved to a label in the local
+# NCBITaxon ontology graph (graph/ncbitaxon).
+#
+# A "mismatch" means the OBO Foundry IRI (e.g. NCBITaxon_48038) exists in
+# our taxonomy annotations but has no rdfs:label in the loaded ontology.
+# This typically happens when using the taxslim subset, which covers only
+# common model organisms. Loading the full NCBITaxon release resolves all
+# taxa from PlantCyc 17.0.
+#
+# Columns:
+#   ?taxon      — the unresolved OBO Foundry IRI
+#   ?nNodes     — how many annotated DataNodes carry this taxon
+#   ?ncbiID     — the numeric NCBI Taxonomy ID (extracted from the IRI)
+#
+# Use the NCBI Taxonomy Browser to look up missing taxa:
+#   https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=<ncbiID>
+#
+# Resolution: load the full NCBITaxon release instead of taxslim:
+#   bash scripts/load-graphs/load-ncbitaxon.sh  (default = full)
+#   bash scripts/load-graphs/load-ncbitaxon.sh --subset taxslim  (smaller)
+
+PREFIX wp:   <http://vocabularies.wikipathways.org/wp#>
+PREFIX ncbi: <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?taxon
+       (STRAFTER(STR(?taxon), "NCBITaxon_") AS ?ncbiID)
+       (COUNT(DISTINCT ?node) AS ?nNodes)
+WHERE {
+  # Step 1: collect all species-specific taxa from our data
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?node wp:organism ?taxon .
+    FILTER(?taxon != ncbi:33090)  # exclude Viridiplantae (pathway-level)
+  }
+  # Step 2: keep only those that have NO label in the NCBITaxon graph
+  FILTER NOT EXISTS {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+      ?taxon rdfs:label ?label .
+    }
+  }
+}
+GROUP BY ?taxon
+ORDER BY DESC(?nNodes)

--- a/1.(Meta)Data/Taxa_Missing_from_NCBITaxon.rq
+++ b/1.(Meta)Data/Taxa_Missing_from_NCBITaxon.rq
@@ -1,41 +1,56 @@
 # Find taxa in PlantMetWiki that cannot be resolved to a label in the local
 # NCBITaxon ontology graph (graph/ncbitaxon).
 #
-# A "mismatch" means the OBO Foundry IRI (e.g. NCBITaxon_48038) exists in
-# our taxonomy annotations but has no rdfs:label in the loaded ontology.
-# This typically happens when using the taxslim subset, which covers only
-# common model organisms. Loading the full NCBITaxon release resolves all
-# taxa from PlantCyc 17.0.
+# Even with the full OBO Foundry NCBITaxon release loaded, some taxa may be
+# absent because:
+#   - The NCBI taxon ID has been deprecated/merged (e.g. NCBITaxon_283673
+#     = Lycopersicon hirsutum, now merged into Solanum habrochaites NCBI 62890)
+#   - The OBO Foundry release does not include every NCBI taxon (it focuses
+#     on biologically relevant taxa used in ontology annotation)
+#
+# Results for PlantCyc 17.0 with the full NCBITaxon release (v2026-05-13):
+#   6 unresolvable taxa · 54 affected GeneProduct/Protein nodes
+#   (all are gene/enzyme annotations, no metabolites affected)
 #
 # Columns:
 #   ?taxon      — the unresolved OBO Foundry IRI
-#   ?nNodes     — how many annotated DataNodes carry this taxon
-#   ?ncbiID     — the numeric NCBI Taxonomy ID (extracted from the IRI)
+#   ?ncbiID     — numeric NCBI Taxonomy ID (extracted from IRI)
+#   ?nNodes     — number of GeneProduct/Protein nodes with this taxon
+#   ?nodeTypes  — entity types (GeneProduct, Protein)
 #
-# Use the NCBI Taxonomy Browser to look up missing taxa:
+# Look up deprecated/merged taxa:
 #   https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?id=<ncbiID>
-#
-# Resolution: load the full NCBITaxon release instead of taxslim:
-#   bash scripts/load-graphs/load-ncbitaxon.sh  (default = full)
-#   bash scripts/load-graphs/load-ncbitaxon.sh --subset taxslim  (smaller)
 
-PREFIX wp:   <http://vocabularies.wikipathways.org/wp#>
-PREFIX ncbi: <http://purl.obolibrary.org/obo/NCBITaxon_>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT ?taxon
+SELECT ?taxon
        (STRAFTER(STR(?taxon), "NCBITaxon_") AS ?ncbiID)
        (COUNT(DISTINCT ?node) AS ?nNodes)
+       (GROUP_CONCAT(DISTINCT STRAFTER(STR(?nodeType), "wp#"); separator=", ") AS ?nodeTypes)
 WHERE {
-  # Step 1: collect all species-specific taxa from our data
+  # Step 1: collect all species-specific taxa from our taxonomy annotations
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
     ?node wp:organism ?taxon .
-    FILTER(?taxon != ncbi:33090)  # exclude Viridiplantae (pathway-level)
+    FILTER(?taxon != ncbi:33090)  # exclude Viridiplantae (pathway-level annotation)
   }
-  # Step 2: keep only those that have NO label in the NCBITaxon graph
+  # Step 2: keep only those with NO label in the NCBITaxon ontology graph
   FILTER NOT EXISTS {
     GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
       ?taxon rdfs:label ?label .
+    }
+  }
+  # Step 3: look up entity type (GeneProduct / Protein) from the pathways graph
+  # Uses UNION to handle both direct typing and DataNode → wp:isAbout indirection
+  OPTIONAL {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+      { ?dn wp:isAbout ?node ; a ?nodeType . }
+      UNION
+      { ?node a ?nodeType . }
+      FILTER(STRSTARTS(STR(?nodeType), "http://vocabularies.wikipathways.org/wp#"))
+      FILTER(?nodeType != wp:DataNode)
     }
   }
 }

--- a/1.(Meta)Data/VoIDHeader.rq
+++ b/1.(Meta)Data/VoIDHeader.rq
@@ -1,11 +1,12 @@
 # Inspect the VoID metadata header describing all PlantMetWiki datasets.
-# Shows dataset names, versions, triple counts, creation dates and source DOIs.
+# Shows dataset names, versions, triple counts, creation dates,
+# clickable Zenodo deposit DOIs (foaf:page), and source provenance.
 PREFIX void:    <http://rdfs.org/ns/void#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX pav:     <http://purl.org/pav/>
-PREFIX dcat:    <http://www.w3.org/ns/dcat#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 
-SELECT ?dataset ?title ?version ?triples ?created ?sourceURI
+SELECT ?dataset ?title ?version ?triples ?created ?depositDOI ?sourceURI
 FROM <http://rdf-plantmetwiki.bioinformatics.nl/void>
 WHERE {
   ?dataset a void:Dataset ;
@@ -13,6 +14,9 @@ WHERE {
            dcterms:hasVersion ?version ;
            pav:createdOn ?created .
   OPTIONAL { ?dataset void:triples ?triples . }
+  # Zenodo deposit DOI — concept DOI always resolves to the latest version
+  OPTIONAL { ?dataset foaf:page ?depositDOI .
+             FILTER(CONTAINS(STR(?depositDOI), "zenodo")) }
   OPTIONAL { ?dataset dcterms:source ?sourceURI . }
 }
 ORDER BY ?title

--- a/1.(Meta)Data/VoIDHeader.rq
+++ b/1.(Meta)Data/VoIDHeader.rq
@@ -1,0 +1,18 @@
+# Inspect the VoID metadata header describing all PlantMetWiki datasets.
+# Shows dataset names, versions, triple counts, creation dates and source DOIs.
+PREFIX void:    <http://rdfs.org/ns/void#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX pav:     <http://purl.org/pav/>
+PREFIX dcat:    <http://www.w3.org/ns/dcat#>
+
+SELECT ?dataset ?title ?version ?triples ?created ?sourceURI
+FROM <http://rdf-plantmetwiki.bioinformatics.nl/void>
+WHERE {
+  ?dataset a void:Dataset ;
+           dcterms:title ?title ;
+           dcterms:hasVersion ?version ;
+           pav:createdOn ?created .
+  OPTIONAL { ?dataset void:triples ?triples . }
+  OPTIONAL { ?dataset dcterms:source ?sourceURI . }
+}
+ORDER BY ?title

--- a/2.PlantMetWiki/Count_PWs_for_SpeciesName.rq
+++ b/2.PlantMetWiki/Count_PWs_for_SpeciesName.rq
@@ -1,16 +1,29 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# Find all pathways containing DataNodes annotated for a given species,
+# and count annotated DataNodes per pathway.
+# Edit the rdfs:label filter to change the species (Latin name).
+# Note: species is at the DataNode level — join via taxonomy-extra graph.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT ?pwID (STR(?titleLit) AS ?title) (count(DISTINCT ?dataNode) as ?nDataNodes)
+SELECT DISTINCT ?pwID (STR(?titleLit) AS ?title) (COUNT(DISTINCT ?dataNode) AS ?nDataNodes)
 WHERE {
-  ?pw rdf:type wp:Pathway ;                    #Filter for pathway type entries
-      dc:identifier ?pwID;                     #Find all pathway IDs
-      wp:organismName "Arabidopsis thaliana" ; #Example organism name using Latin Spelling, example "Arabidopsis thaliana", "Solanum tuberosum", etc. Add one name at a time!!
-      dc:title ?titleLit .                     #Retrieve the pathway title
-  
-  ?dataNode rdf:type wp:DataNode;              #Find all type DataNode entries
-            dcterms:isPartOf ?pw .             #Connect DataNodes to pathways
+  # Step 1: resolve the species name to a taxon IRI via NCBITaxon
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxon rdfs:label "Arabidopsis thaliana" .  # change species name here
+  }
+  # Step 2: find DataNodes annotated with that taxon
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?dataNode wp:organism ?taxon .
+  }
+  # Step 3: connect DataNodes to their pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?dataNode dcterms:isPartOf ?pw .
+    ?pw a wp:Pathway ;
+        dc:identifier ?pwID ;
+        dc:title ?titleLit .
+  }
 }
 GROUP BY ?pwID ?titleLit
 ORDER BY DESC(?nDataNodes)

--- a/2.PlantMetWiki/Metabolites_in_Pathway_for_SpeciesName.rq
+++ b/2.PlantMetWiki/Metabolites_in_Pathway_for_SpeciesName.rq
@@ -1,14 +1,29 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# Find metabolites in pathways that contain DataNodes annotated for a given species.
+# Because metabolites themselves are rarely species-specific, this query finds
+# all metabolites that co-occur in pathways with the requested species' genes/proteins.
+# Edit the rdfs:label filter to change the species.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT ?metabolite ?inchikey (str(?titleLit) as ?title)
+SELECT DISTINCT ?metabolite ?inchikey (STR(?titleLit) AS ?title)
 WHERE {
-  ?metabolite a wp:Metabolite ;                #Filter for metabolite type entries
-    dcterms:isPartOf ?pw .                     #Connect Metabolites to pathways
-  OPTIONAL{?metabolite wp:bdbInChIKey ?inchikey . }      #Find harmonized InChIKeys for metabolites
-  
-  ?pw rdf:type wp:Pathway ;                    #Filter for pathway type entries
-      dc:title ?titleLit ;                     #Retrieve the pathway title
-      wp:organismName "Solanum tuberosum" .    #Example organism name using Latin Spelling, example "Solanum tuberosum". Add one species name at a time!!
-}ORDER BY ASC(?metabolite)
+  # Resolve species name
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxon rdfs:label "Solanum tuberosum" .  # change species name here
+  }
+  # Find a DataNode annotated with that species — gives us the pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?speciesNode wp:organism ?taxon .
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?speciesNode dcterms:isPartOf ?pw .
+    # Find metabolites in the same pathway
+    ?metabolite a wp:Metabolite ;
+                dcterms:isPartOf ?pw .
+    OPTIONAL { ?metabolite wp:bdbInChIKey ?inchikey . }
+    ?pw dc:title ?titleLit .
+  }
+}
+ORDER BY ASC(?metabolite)

--- a/2.PlantMetWiki/Proteins_in_Pathway_for_TaxonID.rq
+++ b/2.PlantMetWiki/Proteins_in_Pathway_for_TaxonID.rq
@@ -1,13 +1,22 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# Find proteins in pathways for a given NCBI taxon ID.
+# The taxonomy-extra graph annotates the biological entity IRI directly
+# (the same IRI that carries rdf:type wp:Protein and dcterms:isPartOf in
+# the pathways graph), so the join is simple: match ?protein across both graphs.
+# Replace ncbi:4113 with the NCBI taxon ID of your species of interest.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
 
-SELECT DISTINCT ?protein (str(?titleLit) as ?title)
+SELECT DISTINCT ?protein (STR(?titleLit) AS ?title)
 WHERE {
-  ?protein a wp:Protein ;                      #Find all type Protein entries
-           dcterms:isPartOf ?pw .              #Connect Proteins to pathways
-  
-  ?pw rdf:type wp:Pathway ;                    #Filter for pathway type entries
-      dc:title ?titleLit ;                     #Retrieve the pathway title
-      wp:organism ncbi:4113 .                  #Example NCBI taxonomy ID for species Solanum tuberosum (potato). Do not use in combination with wp:organismName!!
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?protein wp:organism ncbi:4113 .  # change taxon ID here (4113 = Solanum tuberosum)
   }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?protein a wp:Protein ;
+             dcterms:isPartOf ?pw .
+    ?pw dc:title ?titleLit .
+  }
+}
+ORDER BY ?title

--- a/2.PlantMetWiki/Show_Species_and_TaxonID_Per_PW.rq
+++ b/2.PlantMetWiki/Show_Species_and_TaxonID_Per_PW.rq
@@ -1,12 +1,29 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# Show all species (with NCBI taxon IDs and labels) present in a given pathway.
+# Species are identified from DataNode-level annotations in the taxonomy-extra graph.
+# Replace pmw:PC159 with the pathway ID of interest.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/pathways/>
 
-SELECT ?taxonID ?title #?species
+SELECT DISTINCT ?taxonID ?species ?title
 WHERE {
-  ?pw rdf:type wp:Pathway ;       #Filter for pathway type entries
-      dc:identifier pmw:PC159;    #Enter pathway ID here (example: PC159)
-      #wp:organismName ?species ;  #Collect all species in this pathway by name. Update with NCBi taxon ttl file!!
-      wp:organism ?taxonID ;      #Find NCBI Taxon IDs
-      dc:title ?title .           #Retrieve the title of this pathway
+  # Find the pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw dc:identifier pmw:PC159 ;  # change pathway ID here
+        dc:title ?title .
+    ?dataNode dcterms:isPartOf ?pw .
+  }
+  # Get species annotation on DataNodes in this pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?dataNode wp:organism ?taxonID .
+    FILTER(?taxonID != ncbi:33090)  # exclude pathway-level Viridiplantae
+  }
+  # Resolve taxon label
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxonID rdfs:label ?species .
+  }
 }
+ORDER BY ?species

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/All_BGC_Gene_Links.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/All_BGC_Gene_Links.rq
@@ -1,11 +1,26 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:>
+# List all biosynthetic gene cluster (BGC) → gene links from both MIBiG and plantiSMASH.
+# BGC data lives in two separate named graphs:
+#   graph/bgc-mibig       — MIBiG 4.0 curated clusters
+#   graph/bgc-plantismash — plantiSMASH v2 predicted clusters
+#
+# ro:0000051 = RO "has_part" — links cluster to its member genes.
+PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
+PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
 
-SELECT ?bgc ?gene
+SELECT ?bgc ?gene ?source ?species
 WHERE {
-  ?bgc <http://purl.obolibrary.org/obo/RO_has_part> ?gene .  #Find genes in clusters from MIBIG and PlantIsMash
+  GRAPH ?g {
+    ?bgc a pmw:BiosyntheticGeneCluster ;
+         ro:0000051 ?gene ;
+         dcterms:source ?source .
+    OPTIONAL { ?bgc wp:organismName ?species . }
+  }
+  FILTER(?g IN (
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+  ))
 }
-ORDER BY ?bgc ?gene
+ORDER BY ?source ?bgc ?gene
 LIMIT 1000

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/Check_BGCs_Loaded.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/Check_BGCs_Loaded.rq
@@ -1,24 +1,26 @@
-# Show BGC provenance: which clusters come from MIBiG and which from plantiSMASH,
-# with their gene counts and species annotations.
+# Verify that BGC data is loaded in Virtuoso.
+# Returns cluster count, gene-link count, and species count per source.
+# Expected: MIBiG ≈ 43 clusters · plantiSMASH ≈ 128 Arabidopsis + 63 Solanum clusters.
 PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
 PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
-PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 
-SELECT ?source ?species ?bgc ?bgc_page (COUNT(?gene) AS ?nGenes)
+SELECT ?source
+       (COUNT(DISTINCT ?bgc)     AS ?nClusters)
+       (COUNT(DISTINCT ?gene)    AS ?nGeneLinks)
+       (COUNT(DISTINCT ?species) AS ?nSpecies)
 WHERE {
   GRAPH ?g {
     ?bgc a pmw:BiosyntheticGeneCluster ;
          dcterms:source ?source ;
          ro:0000051 ?gene .
     OPTIONAL { ?bgc wp:organismName ?species . }
-    OPTIONAL { ?bgc foaf:page ?bgc_page . }
   }
   FILTER(?g IN (
     <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
     <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
   ))
 }
-GROUP BY ?source ?species ?bgc ?bgc_page
-ORDER BY ?source ?species ?bgc
+GROUP BY ?source
+ORDER BY ?source

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/Connect_BGC_to_Pathway.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/Connect_BGC_to_Pathway.rq
@@ -1,17 +1,33 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
+# Connect a specific BGC cluster to metabolic pathways via shared genes.
+# BGC membership (ro:0000051) and pathway participant data live in separate graphs;
+# the join is done across three named graphs.
+#
+# Replace BGC0000670 with any MIBiG accession of interest.
+PREFIX pmw:       <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
+PREFIX ro:        <http://purl.obolibrary.org/obo/RO_>
+PREFIX wp:        <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:        <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms:   <http://purl.org/dc/terms/>
 PREFIX bioregistry: <https://bioregistry.io/mibig:>
 
-SELECT DISTINCT ?pwID ?gene (STR(?titleLit) AS ?title)
+SELECT DISTINCT ?pwID ?title ?gene ?source
 WHERE {
-  bioregistry:BGC0000670 ro:0000051 ?gene .    #Find all genes from one specific cluster, e.g. 'BGC0000670'
+  # 1. Gene is a member of the BGC (in bgc-mibig or bgc-plantismash graph)
+  GRAPH ?bgc_graph {
+    bioregistry:BGC0000670 ro:0000051 ?gene ;
+                            dcterms:source ?source .
+  }
+  FILTER(?bgc_graph IN (
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+  ))
 
-  ?interaction wp:participants ?gene ;         #Connect these genes to pathway participants
-               dcterms:isPartOf ?pw .
-  
-  ?pw rdf:type wp:Pathway ;                    #Filter for pathway type entries
-      dc:identifier ?pwID ;                    #Find all pathway IDs
-      dc:title ?titleLit .                     #Find pathway title
+  # 2. Same gene participates in a pathway (in pathways graph)
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?interaction wp:participants ?gene ;
+                 dcterms:isPartOf ?pw .
+    ?pw dc:title ?title ;
+        dc:identifier ?pwID .
+  }
 }
 ORDER BY ?title

--- a/4.Federated/Metabolites_by_InChIKey_with_Involved_Species.rq
+++ b/4.Federated/Metabolites_by_InChIKey_with_Involved_Species.rq
@@ -6,24 +6,45 @@ PREFIX bioregistry: <https://bioregistry.io/mibig:>
 #Federated prefixes:
 PREFIX wd:          <http://www.wikidata.org/entity/> PREFIX wdt:         <http://www.wikidata.org/prop/direct/> PREFIX p:           <http://www.wikidata.org/prop/> PREFIX pq:          <http://www.wikidata.org/prop/qualifier/> 
 
-SELECT DISTINCT ?title (GROUP_CONCAT(DISTINCT ?species; separator=", ") as ?Species) ?inchikey ?wd ?wdLabel
+# Species are now at the DataNode level (not the pathway level).
+# wp:organismName on pathways only returns "Viridiplantae".
+# Strategy: find all entities annotated with a specific species in the same
+# pathway as the metabolite, then look up their label in the NCBITaxon graph.
+# This gives the plant species that co-occur with the metabolite in a pathway.
+
+SELECT DISTINCT ?title (GROUP_CONCAT(DISTINCT ?species; separator=", ") AS ?Species) ?inchikey ?wd ?wdLabel
+FROM <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways>
 WHERE {
-      ?metabolite a wp:Metabolite ;
-                  dcterms:isPartOf ?pw ;
-                  dc:source "InChIKey";
-                  dcterms:identifier ?inchikey .
-  
-      FILTER(?inchikey IN (
-      "BGWGXPAPYGQALX-ARQDHWQXSA-L",
-      "CZMRCDWAGMRECN-UGDNZRGBSA-N",
-      "ASKKPQKSCFYPPP-FVLDFCIYSA-J")) ##metabolite list of interest
+  # Find the metabolite by InChIKey
+  ?metabolite a wp:Metabolite ;
+              dcterms:isPartOf ?pw ;
+              dc:source "InChIKey" ;
+              dcterms:identifier ?inchikey .
 
-      ?pw dc:title ?title ;
-           wp:organismName ?species . ##Do not use together with wp:organism in same query. Update with NCBi taxon ttl file!!
+  FILTER(?inchikey IN (
+    "BGWGXPAPYGQALX-ARQDHWQXSA-L",
+    "CZMRCDWAGMRECN-UGDNZRGBSA-N",
+    "ASKKPQKSCFYPPP-FVLDFCIYSA-J"))  # metabolite list of interest
 
+  ?pw dc:title ?title .
+
+  # Get species from other annotated DataNodes co-occurring in the same pathway
+  # (metabolites are rarely species-specific, so we look at genes/proteins)
+  OPTIONAL {
+    ?speciesNode dcterms:isPartOf ?pw .
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+      ?speciesNode wp:organism ?taxon .
+      FILTER(?taxon != ncbi:33090)   # exclude pathway-level Viridiplantae
+    }
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+      ?taxon rdfs:label ?species .
+    }
+  }
+
+  # Federated: enrich with Wikidata entry via InChIKey
   SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-   
     ?wd wdt:P235 ?inchikey .
     OPTIONAL { ?wd rdfs:label ?wdLabel . FILTER(LANG(?wdLabel) = "en") }
   }
-} ORDER BY ?wd
+}
+ORDER BY ?wd

--- a/4.Federated/SMILES_from_Wikidata.rq
+++ b/4.Federated/SMILES_from_Wikidata.rq
@@ -10,7 +10,7 @@ SELECT DISTINCT ?pwID ?title ?metabolite ?smilesDepict ?inchikey ?wd ?wdLabel
 WHERE {
   {
     SELECT DISTINCT ?pwID ?title ?metabolite ?inchikey
-    FROM <http://plantmetwiki.bioinformatics.nl/>
+    FROM <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways>
     WHERE {
       ?metabolite a wp:Metabolite ;                #Retrieve all DataNodes of Type Metabolite
                   dcterms:isPartOf ?pw ;           #Connect these to specific pathways for priority count later


### PR DESCRIPTION
The PlantMetWiki Virtuoso endpoint now uses 7 separate named graphs instead of a single <http://plantmetwiki.bioinformatics.nl/> graph:

  graph/pathways              — core WikiPathways RDF
  graph/gpml-taxonomy-extra   — wp:organism species annotations
  graph/gpml-properties-extra — PlantCyc key-value properties
  graph/bgc-mibig             — MIBiG 4.0 curated BGCs
  graph/bgc-plantismash       — plantiSMASH v2 predicted BGCs
  graph/ncbitaxon             — NCBITaxon ontology (OBO Foundry, CC0)
  void                        — VoID dataset metadata

Changes to existing queries:
  - All FROM <http://plantmetwiki.bioinformatics.nl/> replaced with FROM <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> (sections 1, 2, 4)
  - BGC queries rewritten to use GRAPH clauses spanning bgc-mibig and bgc-plantismash; RO predicate corrected to ro:0000051
  - Connect_BGC_to_Pathway now cross-joins bgc graph + pathways graph
  - Provenance query shows species and foaf:page link for each cluster

New queries:
  1.(Meta)Data/ListNamedGraphs.rq
    — lists all named graphs with triple counts (replaces the single GraphIsLoaded count) 1.(Meta)Data/GraphIsLoaded.rq — updated: counts per graph filtered to rdf-plantmetwiki namespace 1.(Meta)Data/VoIDHeader.rq — queries the void graph for dataset titles, versions, triples, creation dates and source DOIs 3.Biosynthetic gene cluster (BGC) Crosslinks/Check_BGCs_Loaded.rq — sanity check: counts clusters, gene-links and species per source (expected: MIBiG ~43 clusters, plantiSMASH ~191 clusters)