### PR TITLE
Fix broken queries and add notebook-aligned new queries

### DIFF
--- a/1.(Meta)Data/Entity_Counts.rq
+++ b/1.(Meta)Data/Entity_Counts.rq
@@ -1,0 +1,31 @@
+# Count all major entity types in PlantMetWiki.
+# PC* pathways = WikiPathways-style pathway entries (sequential internal IDs starting with PC).
+# RC* reactions = reaction-level pathway entries (sequential internal IDs starting with RC).
+# Named graphs used:
+#   graph/pathways — all DataNodes, pathways, and interactions
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+
+SELECT
+  (COUNT(DISTINCT ?pc_pathway)    AS ?nPC_Pathways)
+  (COUNT(DISTINCT ?rc_pathway)    AS ?nRC_Reactions)
+  (COUNT(DISTINCT ?gene)          AS ?nGeneProducts)
+  (COUNT(DISTINCT ?protein)       AS ?nProteins)
+  (COUNT(DISTINCT ?metabolite)    AS ?nMetabolites)
+  (COUNT(DISTINCT ?complex)       AS ?nComplexes)
+  (COUNT(DISTINCT ?interaction)   AS ?nInteractions)
+  (COUNT(DISTINCT ?catalysis)     AS ?nCatalysis)
+  (COUNT(DISTINCT ?conversion)    AS ?nConversions)
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    OPTIONAL { ?pc_pathway a wp:Pathway . FILTER(CONTAINS(STR(?pc_pathway), '/PC')) }
+    OPTIONAL { ?rc_pathway a wp:Pathway . FILTER(CONTAINS(STR(?rc_pathway), '/RC')) }
+    OPTIONAL { ?gene       a wp:GeneProduct }
+    OPTIONAL { ?protein    a wp:Protein }
+    OPTIONAL { ?metabolite a wp:Metabolite }
+    OPTIONAL { ?complex    a wp:Complex }
+    OPTIONAL { ?interaction a wp:Interaction }
+    OPTIONAL { ?catalysis   a wp:Catalysis }
+    OPTIONAL { ?conversion  a wp:Conversion }
+  }
+}

--- a/1.(Meta)Data/PlantCyc_PWY_ID_Lookup.rq
+++ b/1.(Meta)Data/PlantCyc_PWY_ID_Lookup.rq
@@ -1,0 +1,26 @@
+# Look up the stable PlantCyc PWY/RXN accession for a given pathway.
+# Shows both the internal sequential PC identifier (from graph/pathways) and
+# the stable PlantCyc accession such as "PWY-5710" (from graph/gpml-properties-extra).
+#
+# Named graphs used:
+#   graph/pathways            — dc:identifier holds internal ID (e.g. "PC629")
+#   graph/gpml-properties-extra — dcterms:identifier holds stable PWY/RXN accession
+#
+# Editable placeholder: change "/PC629_" to any other internal pathway ID fragment,
+#   or remove the FILTER to list all pathways with their stable IDs.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT ?pw ?internalID ?stablePWY_ID
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw a wp:Pathway ;
+        dc:identifier ?internalID .
+    FILTER(CONTAINS(STR(?pw), '/PC629_'))  # Editable: change pathway ID fragment here
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+    ?pw dcterms:identifier ?stablePWY_ID .
+    FILTER(STRSTARTS(?stablePWY_ID, "PWY") || STRSTARTS(?stablePWY_ID, "RXN"))
+  }
+}

--- a/2.PlantMetWiki/CrossSpecies_ReactionCoverage.rq
+++ b/2.PlantMetWiki/CrossSpecies_ReactionCoverage.rq
@@ -1,0 +1,50 @@
+# Cross-species inference: for a given pathway, list every Conversion reaction and which
+# species have an annotated enzyme (GeneProduct or Protein) that catalyses it.
+# This mirrors the cross-species coverage analysis in notebook 03.
+#
+# Named graphs used:
+#   graph/pathways              — pathway, reaction, catalysis, and DataNode triples
+#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession for lookup
+#   graph/gpml-taxonomy-extra   — wp:organism annotations per DataNode
+#   graph/ncbitaxon             — taxon labels
+#
+# Editable placeholder: change "PWY-5710" to any other stable PlantCyc PWY accession.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+
+SELECT ?reactionID ?reaction ?species
+WHERE {
+  # Identify the pathway by stable PWY ID
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+    ?pw dcterms:identifier "PWY-5710" .  # Editable: stable PlantCyc PWY accession
+  }
+
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    # Get all Conversion reactions in this pathway
+    ?reaction a wp:Conversion ;
+              dcterms:isPartOf ?pw ;
+              dc:identifier ?reactionID .
+
+    # Find catalysis interactions linking an enzyme to this reaction
+    ?catalysis a wp:Catalysis ;
+               wp:source ?enzyme ;
+               wp:target ?reaction ;
+               dcterms:isPartOf ?pw .
+
+    # The enzyme must be a GeneProduct or Protein DataNode
+    { ?enzyme a wp:GeneProduct } UNION { ?enzyme a wp:Protein }
+  }
+
+  # Get species annotation for the enzyme
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?enzyme wp:organism ?taxon .
+    FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxon rdfs:label ?species .
+  }
+}
+ORDER BY ?reactionID ?species

--- a/2.PlantMetWiki/Genes_and_Enzymes_per_Species.rq
+++ b/2.PlantMetWiki/Genes_and_Enzymes_per_Species.rq
@@ -1,0 +1,37 @@
+# For every species annotated in the knowledge base, count:
+#   - number of distinct wp:GeneProduct DataNodes
+#   - number of distinct wp:Protein DataNodes
+#   - total gene/protein entities (nTotal)
+#   - number of distinct pathways covered
+# Results sorted by total entity count descending.
+#
+# Named graphs used:
+#   graph/pathways            — DataNode types and pathway membership
+#   graph/gpml-taxonomy-extra — wp:organism annotations per DataNode
+#   graph/ncbitaxon           — taxon labels
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+
+SELECT ?taxon ?species
+  (COUNT(DISTINCT ?gene)     AS ?nGenes)
+  (COUNT(DISTINCT ?protein)  AS ?nProteins)
+  (COUNT(DISTINCT ?pathway)  AS ?nPathways)
+WHERE {
+  # DataNode annotated to a specific species
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+    ?entity wp:organism ?taxon .
+    FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+    ?taxon rdfs:label ?species .
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?entity dcterms:isPartOf ?pathway .
+    OPTIONAL { ?gene a wp:GeneProduct . FILTER(?gene = ?entity) }
+    OPTIONAL { ?protein a wp:Protein . FILTER(?protein = ?entity) }
+  }
+}
+GROUP BY ?taxon ?species
+ORDER BY DESC(COUNT(DISTINCT ?entity))

--- a/2.PlantMetWiki/Interaction_Types_Distribution.rq
+++ b/2.PlantMetWiki/Interaction_Types_Distribution.rq
@@ -1,0 +1,26 @@
+# Count the number of interactions of each wp:Interaction subtype across the whole knowledge base.
+# Subtypes counted: Catalysis, Conversion, TranscriptionTranslation, Inhibition,
+#                   Stimulation, Binding, ComplexBinding.
+#
+# Named graphs used:
+#   graph/pathways — all interaction triples
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?interactionType (COUNT(DISTINCT ?interaction) AS ?nInteractions)
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?interaction rdf:type ?interactionType .
+    VALUES ?interactionType {
+      wp:Catalysis
+      wp:Conversion
+      wp:TranscriptionTranslation
+      wp:Inhibition
+      wp:Stimulation
+      wp:Binding
+      wp:ComplexBinding
+    }
+  }
+}
+GROUP BY ?interactionType
+ORDER BY DESC(?nInteractions)

--- a/2.PlantMetWiki/Pathway_Content_Summary.rq
+++ b/2.PlantMetWiki/Pathway_Content_Summary.rq
@@ -1,0 +1,51 @@
+# Summarise the content of a specific pathway by its stable PlantCyc PWY ID.
+# Returns: pathway title, stable PWY ID, internal PC identifier, counts of each DataNode
+# type (GeneProduct, Protein, Metabolite, Complex), number of distinct species, and
+# number of Conversion reactions.
+#
+# Named graphs used:
+#   graph/pathways              — pathway metadata and DataNode triples
+#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession
+#   graph/gpml-taxonomy-extra   — wp:organism annotations per DataNode
+#   graph/ncbitaxon             — (not queried here; species count via taxonomy-extra)
+#
+# Editable placeholder: change "PWY-5710" to the stable PlantCyc accession of interest.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+
+SELECT ?title ?stablePWY_ID ?internalID
+  (COUNT(DISTINCT ?gene)       AS ?nGenes)
+  (COUNT(DISTINCT ?protein)    AS ?nProteins)
+  (COUNT(DISTINCT ?metabolite) AS ?nMetabolites)
+  (COUNT(DISTINCT ?complex)    AS ?nComplexes)
+  (COUNT(DISTINCT ?taxon)      AS ?nSpecies)
+  (COUNT(DISTINCT ?reaction)   AS ?nReactions)
+WHERE {
+  # Look up pathway by stable PWY ID
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+    ?pw dcterms:identifier "PWY-5710" .  # Editable: stable PlantCyc PWY accession
+    BIND("PWY-5710" AS ?stablePWY_ID)
+  }
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw a wp:Pathway ;
+        dc:title ?title ;
+        dc:identifier ?internalID .
+
+    OPTIONAL { ?gene       a wp:GeneProduct ; dcterms:isPartOf ?pw }
+    OPTIONAL { ?protein    a wp:Protein     ; dcterms:isPartOf ?pw }
+    OPTIONAL { ?metabolite a wp:Metabolite  ; dcterms:isPartOf ?pw }
+    OPTIONAL { ?complex    a wp:Complex     ; dcterms:isPartOf ?pw }
+    OPTIONAL { ?reaction   a wp:Conversion  ; dcterms:isPartOf ?pw }
+  }
+  OPTIONAL {
+    ?anyNode dcterms:isPartOf ?pw .
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+      ?anyNode wp:organism ?taxon .
+      FILTER(?taxon != ncbi:33090)
+    }
+  }
+}
+GROUP BY ?title ?stablePWY_ID ?internalID

--- a/2.PlantMetWiki/Proteins_Names_andReference_forPathwayID.rq
+++ b/2.PlantMetWiki/Proteins_Names_andReference_forPathwayID.rq
@@ -1,16 +1,27 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_>
+# List all proteins (with labels and publication references) for a given pathway.
+# Named graphs used:
+#   graph/pathways — pathway, protein, and reference triples
+# Editable placeholder: change "/PC123_" to the internal pathway ID fragment of interest.
+# Note: dc:identifier holds the internal sequential ID (e.g. "PC123") on the pathway IRI;
+#       use FILTER(CONTAINS(STR(?pw), '/PC123_')) to target a specific pathway.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 
-SELECT DISTINCT ?protein (str(?proteinLabel) as ?proteinName) ?publication
+SELECT DISTINCT ?protein (STR(?proteinLabel) AS ?proteinName) ?publication
 WHERE {
-  ?protein a wp:Protein ;                      #Find all type Protein entries
-           rdfs:label ?proteinLabel ;		   # Add protein label
-           dcterms:isPartOf ?pw .              #Connect Proteins to pathways
-  
-  OPTIONAL{?protein dcterms:references ?publication .} #Find publications describing this protein
-  
-  ?pw rdf:type wp:Pathway ;                    #Filter for pathway type entries
-      dc:title ?titleLit ;                     #Retrieve the pathway title
-      dcterms:identifier "PC123" .             #Filter for pathway of interest
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw rdf:type wp:Pathway ;
+        dc:title ?title .
+    FILTER(CONTAINS(STR(?pw), '/PC123_'))  # change pathway ID fragment here
+
+    ?protein a wp:Protein ;
+             rdfs:label ?proteinLabel ;
+             dcterms:isPartOf ?pw .
+
+    OPTIONAL { ?protein dcterms:references ?publication . }
   }
+}
+ORDER BY ?proteinName

--- a/2.PlantMetWiki/Show_Species_and_TaxonID_Per_PW.rq
+++ b/2.PlantMetWiki/Show_Species_and_TaxonID_Per_PW.rq
@@ -1,19 +1,22 @@
 # Show all species (with NCBI taxon IDs and labels) present in a given pathway.
 # Species are identified from DataNode-level annotations in the taxonomy-extra graph.
-# Replace pmw:PC159 with the pathway ID of interest.
+# Named graphs used:
+#   graph/pathways            — pathway and DataNode triples
+#   graph/gpml-taxonomy-extra — wp:organism annotations per DataNode
+#   graph/ncbitaxon           — taxon labels
+# Editable placeholder: change "/PC159_" to any other internal pathway ID fragment.
 PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
 PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dc:      <http://purl.org/dc/elements/1.1/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
-PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/pathways/>
 
 SELECT DISTINCT ?taxonID ?species ?title
 WHERE {
-  # Find the pathway
+  # Find the pathway by internal sequential ID fragment
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
-    ?pw dc:identifier pmw:PC159 ;  # change pathway ID here
-        dc:title ?title .
+    ?pw dc:title ?title .
+    FILTER(CONTAINS(STR(?pw), '/PC159_'))  # change pathway ID fragment here
     ?dataNode dcterms:isPartOf ?pw .
   }
   # Get species annotation on DataNodes in this pathway

--- a/2.PlantMetWiki/TopPathways_by_GeneCount.rq
+++ b/2.PlantMetWiki/TopPathways_by_GeneCount.rq
@@ -1,0 +1,32 @@
+# List the top N pathways ranked by the number of gene/protein DataNodes they contain.
+# Includes stable PlantCyc PWY/RXN accession from graph/gpml-properties-extra.
+#
+# Named graphs used:
+#   graph/pathways              — pathway, wp:GeneProduct, wp:Protein triples
+#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession
+#
+# Editable placeholder: adjust LIMIT to change how many top pathways are returned.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT ?pw ?internalID ?stablePWY_ID ?title (COUNT(DISTINCT ?entity) AS ?nGeneProducts)
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw a wp:Pathway ;
+        dc:identifier ?internalID ;
+        dc:title ?title .
+
+    ?entity dcterms:isPartOf ?pw .
+    { ?entity a wp:GeneProduct } UNION { ?entity a wp:Protein }
+  }
+  OPTIONAL {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+      ?pw dcterms:identifier ?stablePWY_ID .
+      FILTER(STRSTARTS(?stablePWY_ID, "PWY") || STRSTARTS(?stablePWY_ID, "RXN"))
+    }
+  }
+}
+GROUP BY ?pw ?internalID ?stablePWY_ID ?title
+ORDER BY DESC(?nGeneProducts)
+LIMIT 20

--- a/2.PlantMetWiki/nReferences_per_Pathway.rq
+++ b/2.PlantMetWiki/nReferences_per_Pathway.rq
@@ -1,13 +1,19 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:> 
+# Count the number of distinct publication references per pathway, sorted by most cited.
+# Named graphs used:
+#   graph/pathways — pathway metadata and reference links (dcterms:references, cito:cites)
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX cito:    <http://purl.org/spar/cito/>
 
 SELECT DISTINCT ?pwID ?title (COUNT(DISTINCT ?pubmed) AS ?nPublications)
-WHERE {  
-  ?pw a wp:Pathway ;                            #Define pathways
-      dc:title ?title ;                         #Define pathway titles
-      dc:identifier ?pwID ;                     #Define pathway IDs
-      (dcterms:references|cito:cites) ?pubmed . #Collect total references for pathways  
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?pw a wp:Pathway ;
+        dc:title ?title ;
+        dc:identifier ?pwID ;
+        (dcterms:references|cito:cites) ?pubmed .
+  }
 }
-ORDER BY DESC (?nPublications)
+GROUP BY ?pwID ?title
+ORDER BY DESC(?nPublications)

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/BGC_Pathway_Gene_Crosslinks.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/BGC_Pathway_Gene_Crosslinks.rq
@@ -1,0 +1,46 @@
+# List all (BGC, gene, pathway) crosslinks across both BGC sources and the pathway graph.
+# Join is via shared identifiers.org IRIs: genes typed as wp:GeneProduct in graph/pathways
+# are also listed as ro:0000051 members of BGC clusters in the BGC graphs.
+#
+# Named graphs used:
+#   graph/bgc-mibig       — MIBiG 4.0 curated clusters
+#   graph/bgc-plantismash — plantiSMASH v2 predicted clusters
+#   graph/pathways        — wp:GeneProduct DataNodes linked to pathways via dcterms:isPartOf
+#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession
+PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
+PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT DISTINCT ?bgc ?bgcSource ?gene ?internalPwID ?stablePWY_ID ?pwTitle
+WHERE {
+  # Get BGC → gene links from either BGC graph
+  GRAPH ?bgcGraph {
+    ?bgc a pmw:BiosyntheticGeneCluster ;
+         dcterms:source ?bgcSource ;
+         ro:0000051 ?gene .
+  }
+  FILTER(?bgcGraph IN (
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+  ))
+
+  # Same gene IRI must be a GeneProduct DataNode in a pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?gene a wp:GeneProduct ;
+          dcterms:isPartOf ?pw .
+    ?pw dc:identifier ?internalPwID ;
+        dc:title ?pwTitle .
+  }
+
+  # Enrich with stable PlantCyc accession
+  OPTIONAL {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+      ?pw dcterms:identifier ?stablePWY_ID .
+      FILTER(STRSTARTS(?stablePWY_ID, "PWY") || STRSTARTS(?stablePWY_ID, "RXN"))
+    }
+  }
+}
+ORDER BY ?bgcSource ?bgc ?gene

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/BGCs_Without_Pathway_Connection.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/BGCs_Without_Pathway_Connection.rq
@@ -1,0 +1,35 @@
+# Find BGCs that have NO shared gene with any PlantCyc pathway in graph/pathways.
+# Uses FILTER NOT EXISTS to identify disconnected clusters.
+# Useful for identifying BGCs whose enzymes are not yet represented in PlantCyc.
+#
+# Named graphs used:
+#   graph/bgc-mibig       — MIBiG 4.0 curated clusters
+#   graph/bgc-plantismash — plantiSMASH v2 predicted clusters
+#   graph/pathways        — wp:GeneProduct DataNodes linked to pathways
+PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
+PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT DISTINCT ?bgc ?bgcSource (COUNT(DISTINCT ?gene) AS ?nGenes)
+WHERE {
+  # Get BGC and its member genes
+  GRAPH ?bgcGraph {
+    ?bgc a pmw:BiosyntheticGeneCluster ;
+         dcterms:source ?bgcSource ;
+         ro:0000051 ?gene .
+  }
+  FILTER(?bgcGraph IN (
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+  ))
+
+  # Exclude BGCs where at least one gene is in graph/pathways as a GeneProduct
+  FILTER NOT EXISTS {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+      ?gene a wp:GeneProduct .
+    }
+  }
+}
+GROUP BY ?bgc ?bgcSource
+ORDER BY ?bgcSource ?bgc

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/Check_BGCs_Loaded.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/Check_BGCs_Loaded.rq
@@ -1,6 +1,6 @@
 # Verify that BGC data is loaded in Virtuoso.
 # Returns cluster count, gene-link count, and species count per source.
-# Expected: MIBiG ≈ 43 clusters · plantiSMASH ≈ 128 Arabidopsis + 63 Solanum clusters.
+# Expected: MIBiG ≈ 43 clusters (9 A. thaliana + 34 untyped) · plantiSMASH ≈ 65 A. thaliana clusters.
 PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
 PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
 PREFIX dcterms: <http://purl.org/dc/terms/>

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/Connect_BGC_to_Pathway.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/Connect_BGC_to_Pathway.rq
@@ -22,10 +22,11 @@ WHERE {
     <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
   ))
 
-  # 2. Same gene participates in a pathway (in pathways graph)
+  # 2. Same gene is part of a pathway (in pathways graph)
+  # wp:GeneProduct DataNodes link directly to pathways via dcterms:isPartOf
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
-    ?interaction wp:participants ?gene ;
-                 dcterms:isPartOf ?pw .
+    ?gene a wp:GeneProduct ;
+          dcterms:isPartOf ?pw .
     ?pw dc:title ?title ;
         dc:identifier ?pwID .
   }

--- a/3.Biosynthetic gene cluster (BGC) Crosslinks/Top_Pathways_by_BGC_Genes.rq
+++ b/3.Biosynthetic gene cluster (BGC) Crosslinks/Top_Pathways_by_BGC_Genes.rq
@@ -1,0 +1,46 @@
+# List pathways ranked by the number of BGC-linked genes they contain.
+# For each pathway, reports: stable PWY ID, title, number of connected distinct BGCs,
+# and number of shared genes. Mirrors the analysis in notebook 07, section 6.
+#
+# Named graphs used:
+#   graph/bgc-mibig         — MIBiG 4.0 curated clusters
+#   graph/bgc-plantismash   — plantiSMASH v2 predicted clusters
+#   graph/pathways          — wp:GeneProduct DataNodes linked to pathways
+#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession
+PREFIX pmw:     <http://rdf-plantmetwiki.bioinformatics.nl/vocab/>
+PREFIX ro:      <http://purl.obolibrary.org/obo/RO_>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+SELECT ?pw ?stablePWY_ID ?pwTitle
+  (COUNT(DISTINCT ?bgc)  AS ?nBGCs)
+  (COUNT(DISTINCT ?gene) AS ?nSharedGenes)
+WHERE {
+  # Get BGC → gene links from either BGC graph
+  GRAPH ?bgcGraph {
+    ?bgc a pmw:BiosyntheticGeneCluster ;
+         ro:0000051 ?gene .
+  }
+  FILTER(?bgcGraph IN (
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-mibig>,
+    <http://rdf-plantmetwiki.bioinformatics.nl/graph/bgc-plantismash>
+  ))
+
+  # Same gene must be a GeneProduct DataNode in a pathway
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?gene a wp:GeneProduct ;
+          dcterms:isPartOf ?pw .
+    ?pw dc:title ?pwTitle .
+  }
+
+  # Enrich with stable PlantCyc accession
+  OPTIONAL {
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
+      ?pw dcterms:identifier ?stablePWY_ID .
+      FILTER(STRSTARTS(?stablePWY_ID, "PWY") || STRSTARTS(?stablePWY_ID, "RXN"))
+    }
+  }
+}
+GROUP BY ?pw ?stablePWY_ID ?pwTitle
+ORDER BY DESC(COUNT(DISTINCT ?gene))

--- a/4.Federated/Metabolites_by_Name_with_Involved_Species.rq
+++ b/4.Federated/Metabolites_by_Name_with_Involved_Species.rq
@@ -1,33 +1,59 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:> 
+# Find metabolites by name, list the pathways they appear in, and which plant species
+# are annotated in those pathways (via DataNode-level taxonomy, not pathway-level wp:organismName).
+# Also enriches each metabolite with Wikidata active ingredient info (federated query).
+#
+# Named graphs used:
+#   graph/pathways            — metabolite and pathway triples
+#   graph/gpml-taxonomy-extra — wp:organism annotations per DataNode
+#   graph/ncbitaxon           — taxon labels
+# Federated endpoint: https://qlever.cs.uni-freiburg.de/api/wikidata
+#
+# Editable placeholder: update the FILTER values with metabolite names of interest.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX wd:      <http://www.wikidata.org/entity/>
+PREFIX wdt:     <http://www.wikidata.org/prop/direct/>
 
-#Federated prefixes:
-PREFIX wd:          <http://www.wikidata.org/entity/> PREFIX wdt:         <http://www.wikidata.org/prop/direct/> PREFIX p:           <http://www.wikidata.org/prop/> PREFIX pq:          <http://www.wikidata.org/prop/qualifier/> 
-
-SELECT ?pwID (GROUP_CONCAT(DISTINCT ?species; separator=", ") as ?Species) ?name ?wd ?ingredientLabel
+SELECT ?pwID (GROUP_CONCAT(DISTINCT ?species; separator=", ") AS ?Species) ?name ?wd ?ingredientLabel
 WHERE {
-  ?metabolite a wp:Metabolite ;                	#Retrieve all DataNodes of Type Metabolite
-              rdfs:label ?name ;				#To connect ot textLabels for chemical compounds/Metabolites
-              dcterms:isPartOf ?pw ;           	#Connect these to specific pathways for priority count later
-              dc:source "InChIKey" ;           	#Database for annotations is InChIKey
-              dcterms:identifier ?inchikey .   	#Retrieve InChIKey
-  
-  ##metabolite list with names of interest 
-  FILTER(?name IN ( "caffeine",
-      		  "theobromine",
-      		  "xanthine",
-                    "7-methylxanthine")) 
-  
-   ?pw a wp:Pathway ;                          #Define pathways
-       dc:identifier ?pwID ; 				   #Collect the pathway IDs
-       wp:organismName ?species .			   #Retrieve the species in which this compound is produced/consumed
-  
-  
-  SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-     ?wd wdt:P235  ?inchikey .
-     OPTIONAL {?wd wdt:P3780 ?ingredient .
-     ?ingredient rdfs:label ?ingredientLabel . FILTER(LANG(?ingredientLabel) = "en") }
+  # Find metabolites by name in the pathways graph
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?metabolite a wp:Metabolite ;
+                rdfs:label ?name ;
+                dcterms:isPartOf ?pw ;
+                dc:source "InChIKey" ;
+                dcterms:identifier ?inchikey .
+
+    ?pw a wp:Pathway ;
+        dc:identifier ?pwID .
+
+    # Editable: metabolite names of interest
+    FILTER(?name IN ("caffeine", "theobromine", "xanthine", "7-methylxanthine"))
   }
-} ORDER BY ?name
+
+  # Get species from DataNodes co-occurring in the same pathway
+  OPTIONAL {
+    ?speciesNode dcterms:isPartOf ?pw .
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+      ?speciesNode wp:organism ?taxon .
+      FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
+    }
+    GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+      ?taxon rdfs:label ?species .
+    }
+  }
+
+  # Federated: enrich with Wikidata active ingredient info via InChIKey
+  SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+    ?wd wdt:P235 ?inchikey .
+    OPTIONAL {
+      ?wd wdt:P3780 ?ingredient .
+      ?ingredient rdfs:label ?ingredientLabel .
+      FILTER(LANG(?ingredientLabel) = "en")
+    }
+  }
+}
+ORDER BY ?name

--- a/4.Federated/SMILES_from_Wikidata.rq
+++ b/4.Federated/SMILES_from_Wikidata.rq
@@ -1,29 +1,51 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:> 
-
-#Federated prefixes:
-PREFIX wd:          <http://www.wikidata.org/entity/> PREFIX wdt:         <http://www.wikidata.org/prop/direct/> PREFIX p:           <http://www.wikidata.org/prop/> PREFIX pq:          <http://www.wikidata.org/prop/qualifier/> 
+# Retrieve metabolites (with InChIKey and SMILES) from pathways that have a specific species
+# annotated at the DataNode level, enriched via Wikidata federated query.
+# Species filtering uses graph/gpml-taxonomy-extra + graph/ncbitaxon (NOT wp:organismName,
+# which only returns "Viridiplantae" at pathway level).
+#
+# Named graphs used:
+#   graph/pathways            — metabolite and pathway triples
+#   graph/gpml-taxonomy-extra — wp:organism annotations per DataNode
+#   graph/ncbitaxon           — taxon labels
+# Federated endpoint: https://qlever.cs.uni-freiburg.de/api/wikidata
+#
+# Editable placeholder: change the FILTER on ?speciesLabel to another species name.
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX wd:      <http://www.wikidata.org/entity/>
+PREFIX wdt:     <http://www.wikidata.org/prop/direct/>
 
 SELECT DISTINCT ?pwID ?title ?metabolite ?smilesDepict ?inchikey ?wd ?wdLabel
 WHERE {
   {
     SELECT DISTINCT ?pwID ?title ?metabolite ?inchikey
-    FROM <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways>
     WHERE {
-      ?metabolite a wp:Metabolite ;                #Retrieve all DataNodes of Type Metabolite
-                  dcterms:isPartOf ?pw ;           #Connect these to specific pathways for priority count later
-                  dc:source "InChIKey" ;           #Database for annotations is InChIKey
-                  dcterms:identifier ?inchikey .   #Retrieve InChIKey
+      GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+        ?metabolite a wp:Metabolite ;
+                    dcterms:isPartOf ?pw ;
+                    dc:source "InChIKey" ;
+                    dcterms:identifier ?inchikey .
 
-      ?pw a wp:Pathway ;                           #Define pathways
-          dc:identifier ?pwID ;					           #Collect the pathway IDs
-          dc:title ?titleLit ;
-          wp:organismName "Solanum tuberosum" .    #Do not use together with wp:organism. Update with NCBi taxon ttl file!!
-      BIND(STR(?titleLit) AS ?title)
-
+        ?pw a wp:Pathway ;
+            dc:identifier ?pwID ;
+            dc:title ?titleLit .
+        BIND(STR(?titleLit) AS ?title)
       }
+
+      # Find pathways that contain at least one DataNode annotated to the species of interest
+      ?annotatedNode dcterms:isPartOf ?pw .
+      GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+        ?annotatedNode wp:organism ?taxon .
+        FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
+      }
+      GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+        ?taxon rdfs:label ?speciesLabel .
+        FILTER(?speciesLabel = "Solanum tuberosum")  # Editable: change species name here
+      }
+    }
     LIMIT 10
   }
 


### PR DESCRIPTION
Fixes (7 files):
- Show_Species_and_TaxonID_Per_PW: replace dc:identifier pmw:PC159 (invalid) with FILTER(CONTAINS(STR(?pw), '/PC159_')); drop unused pmw: prefix
- Proteins_Names_andReference_forPathwayID: rewrite with one PREFIX per line, scope to GRAPH <pathways>, replace dcterms:identifier "PC123" (wrong graph) with FILTER on pathway IRI; add ORDER BY
- nReferences_per_Pathway: reformat prefixes one per line, remove unused prefixes, scope to GRAPH <pathways>, add GROUP BY (required for aggregates)
- Check_BGCs_Loaded: correct comment to 65 A. thaliana plantiSMASH clusters (was "128 Arabidopsis + 63 Solanum")
- Connect_BGC_to_Pathway: replace non-existent wp:participants predicate with ?gene a wp:GeneProduct ; dcterms:isPartOf ?pw
- Metabolites_by_Name_with_Involved_Species: replace wp:organismName (returns only "Viridiplantae") with gpml-taxonomy-extra + ncbitaxon join
- SMILES_from_Wikidata: same wp:organismName fix; replace FROM with GRAPH blocks, scope inner SELECT to named graphs

New queries (10 files):
- 1.(Meta)Data/Entity_Counts.rq
- 1.(Meta)Data/PlantCyc_PWY_ID_Lookup.rq
- 2.PlantMetWiki/TopPathways_by_GeneCount.rq
- 2.PlantMetWiki/Interaction_Types_Distribution.rq
- 2.PlantMetWiki/CrossSpecies_ReactionCoverage.rq
- 2.PlantMetWiki/Genes_and_Enzymes_per_Species.rq
- 2.PlantMetWiki/Pathway_Content_Summary.rq
- 3.Biosynthetic gene cluster (BGC) Crosslinks/BGC_Pathway_Gene_Crosslinks.rq
- 3.Biosynthetic gene cluster (BGC) Crosslinks/BGCs_Without_Pathway_Connection.rq
- 3.Biosynthetic gene cluster (BGC) Crosslinks/Top_Pathways_by_BGC_Genes.rq