### PR TITLE
Fix 4 failing queries: timeout, missing predicate, Qlever 429, GROUP_…

### DIFF
--- a/1.(Meta)Data/Entity_Counts.rq
+++ b/1.(Meta)Data/Entity_Counts.rq
@@ -1,31 +1,51 @@
 # Count all major entity types in PlantMetWiki.
 # PC* pathways = WikiPathways-style pathway entries (sequential internal IDs starting with PC).
 # RC* reactions = reaction-level pathway entries (sequential internal IDs starting with RC).
+#
 # Named graphs used:
 #   graph/pathways — all DataNodes, pathways, and interactions
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
-PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+#
+# Implementation note: uses UNION instead of multiple OPTIONAL patterns.
+# Multiple OPTIONAL patterns in a single query time out in Virtuoso because the
+# optimizer cannot push each OPTIONAL into an independent scan.
+# UNION allows each entity type to be counted separately and efficiently.
 
-SELECT
-  (COUNT(DISTINCT ?pc_pathway)    AS ?nPC_Pathways)
-  (COUNT(DISTINCT ?rc_pathway)    AS ?nRC_Reactions)
-  (COUNT(DISTINCT ?gene)          AS ?nGeneProducts)
-  (COUNT(DISTINCT ?protein)       AS ?nProteins)
-  (COUNT(DISTINCT ?metabolite)    AS ?nMetabolites)
-  (COUNT(DISTINCT ?complex)       AS ?nComplexes)
-  (COUNT(DISTINCT ?interaction)   AS ?nInteractions)
-  (COUNT(DISTINCT ?catalysis)     AS ?nCatalysis)
-  (COUNT(DISTINCT ?conversion)    AS ?nConversions)
+PREFIX wp: <http://vocabularies.wikipathways.org/wp#>
+
+SELECT ?entityType (COUNT(DISTINCT ?entity) AS ?count)
 WHERE {
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
-    OPTIONAL { ?pc_pathway a wp:Pathway . FILTER(CONTAINS(STR(?pc_pathway), '/PC')) }
-    OPTIONAL { ?rc_pathway a wp:Pathway . FILTER(CONTAINS(STR(?rc_pathway), '/RC')) }
-    OPTIONAL { ?gene       a wp:GeneProduct }
-    OPTIONAL { ?protein    a wp:Protein }
-    OPTIONAL { ?metabolite a wp:Metabolite }
-    OPTIONAL { ?complex    a wp:Complex }
-    OPTIONAL { ?interaction a wp:Interaction }
-    OPTIONAL { ?catalysis   a wp:Catalysis }
-    OPTIONAL { ?conversion  a wp:Conversion }
+    {
+      ?entity a wp:Pathway .
+      FILTER(CONTAINS(STR(?entity), '/PC'))
+      BIND("1_PC_Pathways" AS ?entityType)
+    } UNION {
+      ?entity a wp:Pathway .
+      FILTER(CONTAINS(STR(?entity), '/RC'))
+      BIND("2_RC_Reactions" AS ?entityType)
+    } UNION {
+      ?entity a wp:GeneProduct .
+      BIND("3_GeneProducts" AS ?entityType)
+    } UNION {
+      ?entity a wp:Protein .
+      BIND("4_Proteins" AS ?entityType)
+    } UNION {
+      ?entity a wp:Metabolite .
+      BIND("5_Metabolites" AS ?entityType)
+    } UNION {
+      ?entity a wp:Complex .
+      BIND("6_Complexes" AS ?entityType)
+    } UNION {
+      ?entity a wp:Interaction .
+      BIND("7_Interactions_total" AS ?entityType)
+    } UNION {
+      ?entity a wp:Catalysis .
+      BIND("8_Catalysis" AS ?entityType)
+    } UNION {
+      ?entity a wp:Conversion .
+      BIND("9_Conversions" AS ?entityType)
+    }
   }
 }
+GROUP BY ?entityType
+ORDER BY ?entityType

--- a/2.PlantMetWiki/CrossSpecies_ReactionCoverage.rq
+++ b/2.PlantMetWiki/CrossSpecies_ReactionCoverage.rq
@@ -1,48 +1,57 @@
-# Cross-species inference: for a given pathway, list every Conversion reaction and which
-# species have an annotated enzyme (GeneProduct or Protein) that catalyses it.
-# This mirrors the cross-species coverage analysis in notebook 03.
+# Cross-species inference: for a given pathway, list every Conversion reaction
+# and which species have an annotated enzyme (GeneProduct or Protein) that catalyses it.
+# Mirrors the cross-species coverage analysis in notebook 03.
 #
 # Named graphs used:
+#   graph/gpml-properties-extra — stable PWY/RXN accession lookup
 #   graph/pathways              — pathway, reaction, catalysis, and DataNode triples
-#   graph/gpml-properties-extra — dcterms:identifier = stable PWY/RXN accession for lookup
-#   graph/gpml-taxonomy-extra   — wp:organism annotations per DataNode
+#   graph/gpml-taxonomy-extra   — wp:organism annotations per entity
 #   graph/ncbitaxon             — taxon labels
 #
-# Editable placeholder: change "PWY-5710" to any other stable PlantCyc PWY accession.
+# Editable placeholder: change "PWY-5710" to any stable PlantCyc PWY accession.
+# Browse available PWY IDs with the PlantCyc_PWY_ID_Lookup.rq query.
+#
+# Note: wp:Conversion nodes do not carry dc:identifier. The reaction ID is extracted
+# from the IRI tail (e.g. ".../Interaction/RXN_21443" -> "RXN-21443").
+# GPML anchor sub-nodes (IRI contains "_anchor_") are diagram artefacts, not
+# biochemical reactions, and are excluded.
+
 PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
 PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX dc:      <http://purl.org/dc/elements/1.1/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
 
-SELECT ?reactionID ?reaction ?species
+SELECT ?reactionID ?species
 WHERE {
-  # Identify the pathway by stable PWY ID
+  # Identify pathway by stable PWY ID stored in graph/gpml-properties-extra
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-properties-extra> {
-    ?pw dcterms:identifier "PWY-5710" .  # Editable: stable PlantCyc PWY accession
+    ?pw dcterms:identifier "PWY-5710" .  # change to any PWY/RXN accession
   }
 
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
-    # Get all Conversion reactions in this pathway
+    # Real Conversion reactions only (exclude GPML anchor helper sub-nodes)
     ?reaction a wp:Conversion ;
-              dcterms:isPartOf ?pw ;
-              dc:identifier ?reactionID .
+              dcterms:isPartOf ?pw .
+    FILTER(!CONTAINS(STR(?reaction), "_anchor_"))
+    # Extract reaction ID from IRI tail: RXN_21443 -> RXN-21443
+    BIND(REPLACE(STRAFTER(STR(?reaction), "/Interaction/"), "_", "-") AS ?reactionID)
 
-    # Find catalysis interactions linking an enzyme to this reaction
+    # Catalysis linking enzyme -> reaction
     ?catalysis a wp:Catalysis ;
                wp:source ?enzyme ;
                wp:target ?reaction ;
                dcterms:isPartOf ?pw .
 
-    # The enzyme must be a GeneProduct or Protein DataNode
     { ?enzyme a wp:GeneProduct } UNION { ?enzyme a wp:Protein }
   }
 
-  # Get species annotation for the enzyme
+  # Species annotation on the enzyme (identifiers.org IRI, same across graphs)
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
     ?enzyme wp:organism ?taxon .
     FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
   }
+
+  # Resolve taxon IRI to readable species name
   GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
     ?taxon rdfs:label ?species .
   }

--- a/4.Federated/InChIKey_to_Wikidata_for_ChEBI_and_HMDB.rq
+++ b/4.Federated/InChIKey_to_Wikidata_for_ChEBI_and_HMDB.rq
@@ -1,37 +1,56 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:> 
+# Retrieve Wikidata entries, ChEBI IDs, and PubChem CIDs for metabolites
+# in PlantMetWiki, matched via InChIKey (wdt:P235).
+# Returns metabolites that occur in at most one pathway (rare/specialised compounds).
+#
+# Named graphs used:
+#   graph/pathways — metabolite DataNodes with InChIKey identifiers
+#
+# Federation:
+#   https://query.wikidata.org/sparql — chemical metadata via InChIKey
+#
+# Editable parameters:
+#   HAVING clause: change <= 1 to restrict/expand pathway occurrence filter
+#   LIMIT/OFFSET: paginate through results (100 items per page)
 
-#Federated prefixes:
-PREFIX wd:          <http://www.wikidata.org/entity/> PREFIX wdt:         <http://www.wikidata.org/prop/direct/> PREFIX p:           <http://www.wikidata.org/prop/> PREFIX pq:          <http://www.wikidata.org/prop/qualifier/> 
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX wd:      <http://www.wikidata.org/entity/>
+PREFIX wdt:     <http://www.wikidata.org/prop/direct/>
+PREFIX p:       <http://www.wikidata.org/prop/>
+PREFIX pq:      <http://www.wikidata.org/prop/qualifier/>
 
 SELECT DISTINCT ?inchikey ?nPWOcurrences ?wd ?wdLabel ?chebi ?pubchem
 WHERE {
   {
     SELECT ?inchikey (COUNT(DISTINCT ?pwID) AS ?nPWOcurrences)
     WHERE {
-      ?metabolite a wp:Metabolite ;                #Retrieve all DataNodes of Type Metabolite
-                  dcterms:isPartOf ?pw ;           #Connect these to specific pathways for priority count later
-                  dc:source "InChIKey" ;           #Database for annotations is InChIKey
-                  dcterms:identifier ?inchikey .   #Retrieve InChIKey
-      
-      ?pw a wp:Pathway ;                           #Define pathways
-          dc:identifier ?pwID .					   #Collect the pathway IDs
+      GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+        ?metabolite a wp:Metabolite ;
+                    dcterms:isPartOf ?pw ;
+                    dc:source "InChIKey" ;
+                    dcterms:identifier ?inchikey .
+        ?pw a wp:Pathway ;
+            dc:identifier ?pwID .
+      }
     }
-    GROUP BY ?inchikey                             #Results need to be aggregated to apply count
-    HAVING (COUNT(DISTINCT ?pwID) <= 1)            #Retrieve metabolites only found in 1 pathway
-    LIMIT 100 			                           #100 items take around 14 sec to retrieve in Wikidata, 22 in Qlever
-    OFFSET 100									   #To retrieve item 101-200, can be used in a script to collect data from all entries
+    GROUP BY ?inchikey
+    HAVING (COUNT(DISTINCT ?pwID) <= 1)   # specialised metabolites (change limit here)
+    LIMIT 100                              # page size
+    OFFSET 0                              # increment by 100 for next page
   }
 
-  SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
-    ?wd wdt:P235 ?inchikey .             #Connect pathway Metabolites to Wikidata entries via InChIKey
-    OPTIONAL { ?wd rdfs:label ?wdLabel . FILTER(LANG(?wdLabel) = "en") } #Retrieve the label from Wikidata for the metabolite
-    OPTIONAL {  ?wd wdt:P683 ?chebi ;
-                   p:P683 ?internalID .
-               ?internalID pq:P4390 wd:Q39893449 .}     # Retrieve ChEBI ID if available, but only 'exact match' (wd:Q39893449)
-    OPTIONAL { ?wd wdt:P662 ?pubchem . }   # Retrieve PubChem CID if available
-  }  
-} 
-ORDER BY DESC (?nPWOcurrences)
+  # Federated: enrich with Wikidata chemical metadata via InChIKey
+  SERVICE <https://query.wikidata.org/sparql> {
+    ?wd wdt:P235 ?inchikey .
+    OPTIONAL { ?wd rdfs:label ?wdLabel . FILTER(LANG(?wdLabel) = "en") }
+    OPTIONAL {
+      ?wd wdt:P683 ?chebi ;
+          p:P683 ?internalID .
+      ?internalID pq:P4390 wd:Q39893449 .  # ChEBI exact match only
+    }
+    OPTIONAL { ?wd wdt:P662 ?pubchem . }
+  }
+}
+ORDER BY DESC(?nPWOcurrences)

--- a/4.Federated/Metabolites_by_InChIKey_with_Involved_Species.rq
+++ b/4.Federated/Metabolites_by_InChIKey_with_Involved_Species.rq
@@ -1,40 +1,59 @@
-PREFIX biopax:  <http://www.biopax.org/release/biopax-level3.owl#> PREFIX cito:    <http://purl.org/spar/cito/> PREFIX dc:      <http://purl.org/dc/elements/1.1/> PREFIX dcterms: <http://purl.org/dc/terms/> PREFIX foaf:    <http://xmlns.com/foaf/0.1/> PREFIX freq:    <http://purl.org/cld/freq/> PREFIX gpml:    <http://vocabularies.wikipathways.org/gpml#>
-PREFIX owl:     <http://www.w3.org/2002/07/owl#> PREFIX pav:     <http://purl.org/pav/> PREFIX prov:    <http://www.w3.org/ns/prov#> PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#> PREFIX skos:    <http://www.w3.org/2004/02/skos/core#> PREFIX void:    <http://rdfs.org/ns/void#>
-PREFIX wp:      <http://vocabularies.wikipathways.org/wp#> PREFIX wprdf:   <http://rdf.wikipathways.org/> PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#> PREFIX pmw:		<http://rdf-plantmetwiki.bioinformatics.nl/pathways/> PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_> PREFIX ro:		<http://purl.obolibrary.org/obo/RO_> 
-PREFIX bioregistry: <https://bioregistry.io/mibig:> 
+# Find pathways and associated plant species for specific metabolites of interest,
+# identified by their InChIKey. Enriches results with Wikidata entry and label.
+#
+# Species are annotated at the DataNode level (not the pathway level).
+# Strategy: find gene/protein DataNodes co-occurring in the same pathway as the
+# metabolite, then look up their species annotation via graph/gpml-taxonomy-extra
+# and resolve the taxon label from graph/ncbitaxon.
+#
+# Named graphs used:
+#   graph/pathways            — metabolite and DataNode triples
+#   graph/gpml-taxonomy-extra — wp:organism per entity
+#   graph/ncbitaxon           — taxon labels
+#
+# Federation:
+#   https://query.wikidata.org/sparql — Wikidata entry and label via InChIKey (wdt:P235)
+#
+# Editable: replace the InChIKey values in the FILTER to query different metabolites.
+# Note: returns one row per (pathway, species) combination to avoid GROUP_CONCAT
+# string-length errors in Virtuoso.
 
-#Federated prefixes:
-PREFIX wd:          <http://www.wikidata.org/entity/> PREFIX wdt:         <http://www.wikidata.org/prop/direct/> PREFIX p:           <http://www.wikidata.org/prop/> PREFIX pq:          <http://www.wikidata.org/prop/qualifier/> 
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+PREFIX wdt:     <http://www.wikidata.org/prop/direct/>
 
-# Species are now at the DataNode level (not the pathway level).
-# wp:organismName on pathways only returns "Viridiplantae".
-# Strategy: find all entities annotated with a specific species in the same
-# pathway as the metabolite, then look up their label in the NCBITaxon graph.
-# This gives the plant species that co-occur with the metabolite in a pathway.
-
-SELECT DISTINCT ?title (GROUP_CONCAT(DISTINCT ?species; separator=", ") AS ?Species) ?inchikey ?wd ?wdLabel
-FROM <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways>
+SELECT DISTINCT ?title ?species ?inchikey ?wd ?wdLabel
 WHERE {
-  # Find the metabolite by InChIKey
-  ?metabolite a wp:Metabolite ;
-              dcterms:isPartOf ?pw ;
-              dc:source "InChIKey" ;
-              dcterms:identifier ?inchikey .
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    # Find the target metabolite(s) by InChIKey
+    ?metabolite a wp:Metabolite ;
+                dcterms:isPartOf ?pw ;
+                dc:source "InChIKey" ;
+                dcterms:identifier ?inchikey .
 
-  FILTER(?inchikey IN (
-    "BGWGXPAPYGQALX-ARQDHWQXSA-L",
-    "CZMRCDWAGMRECN-UGDNZRGBSA-N",
-    "ASKKPQKSCFYPPP-FVLDFCIYSA-J"))  # metabolite list of interest
+    FILTER(?inchikey IN (
+      "BGWGXPAPYGQALX-ARQDHWQXSA-L",
+      "CZMRCDWAGMRECN-UGDNZRGBSA-N",
+      "ASKKPQKSCFYPPP-FVLDFCIYSA-J"))  # edit: list InChIKeys of interest
 
-  ?pw dc:title ?title .
+    ?pw dc:title ?title .
 
-  # Get species from other annotated DataNodes co-occurring in the same pathway
-  # (metabolites are rarely species-specific, so we look at genes/proteins)
+    # Find gene/protein DataNodes co-occurring in the same pathway
+    # (metabolites are rarely species-specific; species context comes from enzymes)
+    OPTIONAL {
+      ?speciesNode dcterms:isPartOf ?pw .
+      { ?speciesNode a wp:GeneProduct } UNION { ?speciesNode a wp:Protein }
+    }
+  }
+
+  # Resolve species annotation for the co-occurring DataNode
   OPTIONAL {
-    ?speciesNode dcterms:isPartOf ?pw .
     GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
       ?speciesNode wp:organism ?taxon .
-      FILTER(?taxon != ncbi:33090)   # exclude pathway-level Viridiplantae
+      FILTER(?taxon != ncbi:33090)  # exclude pathway-level Viridiplantae
     }
     GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
       ?taxon rdfs:label ?species .
@@ -42,9 +61,9 @@ WHERE {
   }
 
   # Federated: enrich with Wikidata entry via InChIKey
-  SERVICE <https://qlever.cs.uni-freiburg.de/api/wikidata> {
+  SERVICE <https://query.wikidata.org/sparql> {
     ?wd wdt:P235 ?inchikey .
     OPTIONAL { ?wd rdfs:label ?wdLabel . FILTER(LANG(?wdLabel) = "en") }
   }
 }
-ORDER BY ?wd
+ORDER BY ?inchikey ?title ?species


### PR DESCRIPTION
…CONCAT overflow

- Entity_Counts.rq: replace 9-variable OPTIONAL block (Virtuoso timeout) with UNION of single-variable patterns; each type counted independently in O(n) time

- CrossSpecies_ReactionCoverage.rq: wp:Conversion nodes carry no dc:identifier; extract reaction ID from IRI tail with BIND/STRAFTER/REPLACE; also filter GPML anchor sub-nodes (_anchor_) which are diagram artefacts not reactions

- InChIKey_to_Wikidata_for_ChEBI_and_HMDB.rq: switch SERVICE endpoint from Qlever (rate-limited, returning 429) to https://query.wikidata.org/sparql; reformat prefixes one per line; remove unused prefixes

- Metabolites_by_InChIKey_with_Involved_Species.rq: switch Qlever -> Wikidata; replace GROUP_CONCAT (Virtuoso SR478 string-too-long error) with DISTINCT returning one row per (pathway, species) combination; scope metabolite lookup to graph/pathways via GRAPH block instead of FROM clause