### PR TITLE
PlantMetWiki: add BridgeDb metabolite cross-reference queries

### DIFF
--- a/2.PlantMetWiki/BridgeDb_Coverage_Summary.rq
+++ b/2.PlantMetWiki/BridgeDb_Coverage_Summary.rq
@@ -1,0 +1,17 @@
+# Count how many wp:Metabolite nodes carry a BridgeDb-materialised cross-reference
+# to each external chemical database. Shows the reach of the BridgeDb metabolite
+# mapping in PlantMetWiki (release v3.2): e.g. Wikidata, PubChem and ChEBI each
+# reach ~3,000 metabolites, up from a handful of source identifiers.
+PREFIX wp: <http://vocabularies.wikipathways.org/wp#>
+
+SELECT ?database (COUNT(DISTINCT ?m) AS ?nMetabolites)
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?m a wp:Metabolite ; ?p ?o .
+    VALUES ?p { wp:bdbChEBI wp:bdbWikidata wp:bdbPubChem wp:bdbHmdb
+                wp:bdbKeggCompound wp:bdbChemspider wp:bdbLipidMaps wp:bdbInChIKey }
+    BIND(REPLACE(STR(?p), ".*#bdb", "") AS ?database)
+  }
+}
+GROUP BY ?database
+ORDER BY DESC(?nMetabolites)

--- a/2.PlantMetWiki/BridgeDb_Metabolite_CrossReferences.rq
+++ b/2.PlantMetWiki/BridgeDb_Metabolite_CrossReferences.rq
@@ -1,0 +1,22 @@
+# List PlantMetWiki metabolites with the external cross-references materialised
+# by BridgeDb (wp:bdb* predicates: ChEBI, Wikidata, PubChem, HMDB, KEGG, ...).
+# These links are stored directly in the graph, so no federation is needed to
+# resolve a metabolite to its ChEBI / Wikidata / PubChem entries.
+# Added by the BridgeDb metabolite ID mapping (release v3.2, build 20260102).
+PREFIX wp:   <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?name ?ChEBI ?Wikidata ?PubChem ?HMDB ?KEGG
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?m a wp:Metabolite .
+    OPTIONAL { ?m rdfs:label        ?name }
+    OPTIONAL { ?m wp:bdbChEBI        ?ChEBI }
+    OPTIONAL { ?m wp:bdbWikidata     ?Wikidata }
+    OPTIONAL { ?m wp:bdbPubChem      ?PubChem }
+    OPTIONAL { ?m wp:bdbHmdb         ?HMDB }
+    OPTIONAL { ?m wp:bdbKeggCompound ?KEGG }
+    FILTER(BOUND(?ChEBI) || BOUND(?Wikidata) || BOUND(?PubChem))
+  }
+}
+LIMIT 100

--- a/2.PlantMetWiki/Metabolite_by_PubChem_ID.rq
+++ b/2.PlantMetWiki/Metabolite_by_PubChem_ID.rq
@@ -1,0 +1,36 @@
+# Search PlantMetWiki starting from an external database identifier — here a
+# PubChem Compound ID — and return the metabolite, its pathways and the species
+# with annotated enzymes in those pathways.
+# Enabled by BridgeDb: the PubChem link is stored directly in the graph, so this
+# resolves without a federated query. Before BridgeDb this was not possible.
+# Example CID 28523 = alpha-tomatine. Change the CID URI to search another compound
+# (or swap wp:bdbPubChem for wp:bdbChEBI / wp:bdbHmdb / wp:bdbWikidata to search
+# from a different database).
+PREFIX wp:      <http://vocabularies.wikipathways.org/wp#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX ncbi:    <http://purl.obolibrary.org/obo/NCBITaxon_>
+
+SELECT DISTINCT ?metabolite ?pathway ?species
+WHERE {
+  GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/pathways> {
+    ?m a wp:Metabolite ;
+       wp:bdbPubChem <http://rdf.ncbi.nlm.nih.gov/pubchem/compound/CID28523> .  # change CID here
+    OPTIONAL { ?m rdfs:label ?metabolite }
+    OPTIONAL {
+      ?m dcterms:isPartOf ?pw .
+      ?pw a wp:Pathway ; dc:title ?pathway .
+      OPTIONAL {
+        ?node dcterms:isPartOf ?pw .
+        GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/gpml-taxonomy-extra> {
+          ?node wp:organism ?taxon . FILTER(?taxon != ncbi:33090)
+        }
+        GRAPH <http://rdf-plantmetwiki.bioinformatics.nl/graph/ncbitaxon> {
+          ?taxon rdfs:label ?species
+        }
+      }
+    }
+  }
+}
+ORDER BY ?pathway ?species


### PR DESCRIPTION
Three queries using the wp:bdb* cross-references materialised by BridgeDb (release v3.2): list metabolite cross-references, per-database coverage summary, and a database-first search (PubChem ID -> metabolite/pathways/species) that resolves in-graph without federation.